### PR TITLE
Fix drag n drop

### DIFF
--- a/lib/admin.php
+++ b/lib/admin.php
@@ -139,6 +139,8 @@ class Genesis_Simple_Share_Boxes extends Genesis_Admin_Boxes {
 	 *
 	 */
 	function scripts() {
+
+		global $wp_styles;
 	
 		wp_enqueue_script( 'common' );
 		wp_enqueue_script( 'wp-lists' );
@@ -174,6 +176,14 @@ class Genesis_Simple_Share_Boxes extends Genesis_Admin_Boxes {
 							array(), 
 							'0.1.0' 
 						);
+
+		wp_enqueue_style( 	'genesis-simple-share-admin-css-ie',
+							plugins_url( 'css/admin-ie.css', __FILE__ ),
+							array( 'genesis-simple-share-admin-css' ),
+							'0.1.0'
+						);
+		//* Add IE Styles
+		$wp_styles->add_data( 'genesis-simple-share-admin-css-ie', 'conditional', 'lt IE 10' );
 		
 	}
 	

--- a/lib/css/admin.css
+++ b/lib/css/admin.css
@@ -24,8 +24,18 @@
 
 .genesis_page_genesis_simple_share_settings .meta-box-sortables .postbox,
 .genesis_page_genesis_simple_share_settings .meta-box-sortables .sortable-placeholder {
+	display: -webkit-box;
+	display: -webkit-flex;
+	display: -ms-flexbox;
 	display: flex;
-	flex-wrap: wrap;
+	-webkit-flex-wrap: wrap;
+	    -ms-flex-wrap: wrap;
+	        flex-wrap: wrap;
+	-webkit-box-orient: horizontal;
+	-webkit-box-direction: normal;
+	-webkit-flex-direction: row;
+	    -ms-flex-direction: row;
+	        flex-direction: row;
 	min-height: 240px;
 	margin: 5px;
 	width: 260px;

--- a/lib/css/admin.css
+++ b/lib/css/admin.css
@@ -22,8 +22,7 @@
 	margin-bottom: 20px;
 }
 
-.genesis_page_genesis_simple_share_settings .meta-box-sortables .postbox,
-.genesis_page_genesis_simple_share_settings .meta-box-sortables .sortable-placeholder {
+#main-sortables {
 	display: -webkit-box;
 	display: -webkit-flex;
 	display: -ms-flexbox;
@@ -36,7 +35,12 @@
 	-webkit-flex-direction: row;
 	    -ms-flex-direction: row;
 	        flex-direction: row;
+}
+
+.genesis_page_genesis_simple_share_settings .meta-box-sortables .postbox,
+.genesis_page_genesis_simple_share_settings .meta-box-sortables .sortable-placeholder {
 	min-height: 240px;
+	float: left;
 	margin: 5px;
 	width: 260px;
 }

--- a/lib/css/admin.css
+++ b/lib/css/admin.css
@@ -24,9 +24,9 @@
 
 .genesis_page_genesis_simple_share_settings .meta-box-sortables .postbox,
 .genesis_page_genesis_simple_share_settings .meta-box-sortables .sortable-placeholder {
-	display: block;
-	float: left;
-	height: 240px;
+	display: flex;
+	flex-wrap: wrap;
+	min-height: 240px;
 	margin: 5px;
 	width: 260px;
 }

--- a/lib/css/ie-admin.css
+++ b/lib/css/ie-admin.css
@@ -1,0 +1,7 @@
+/* IE 9 and below */
+.genesis_page_genesis_simple_share_settings .meta-box-sortables .postbox,
+.genesis_page_genesis_simple_share_settings .meta-box-sortables .sortable-placeholder {
+	display: block;
+	float: left;
+	height: 240px;
+}

--- a/lib/css/ie-admin.css
+++ b/lib/css/ie-admin.css
@@ -1,4 +1,8 @@
 /* IE 9 and below */
+#main-sortables {
+	display: block;
+}
+
 .genesis_page_genesis_simple_share_settings .meta-box-sortables .postbox,
 .genesis_page_genesis_simple_share_settings .meta-box-sortables .sortable-placeholder {
 	display: block;


### PR DESCRIPTION
use flex box to style the drag-n-drop boxes. Included IE 9 and below fallback with original styling.